### PR TITLE
Johnny/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ const params = {
   arg2: [123, 12],
 };
 
-// AsyncSingleton enforces params to be { arg1: string, arg2: number[] }
-const singleton = await AsyncSingleton(ExampleService, params);
+// Singleton enforces params to be { arg1: string, arg2: number[] }
+const singleton = Singleton(ExampleService, params);
 const instance1 = singleton.getInstance();
 const instance2 = singleton.getInstance();
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ console.log(instance1 === instance2);
 ```
 
 **initialize function** can have any signature and accepts any parameters. 
-You will need to pass these parameters into the Singleton or AsyncSingleton function.
+You will need to pass these parameters into *Singleton* or *AsyncSingleton* function.
 
 ```ts
 class ExampleService {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚀 ts-singleton
+# 🚀 ts-singletonify
 
 ![GitHub License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![TypeScript](https://img.shields.io/badge/language-TypeScript-blue)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ expect(instance1.initialized).toBe(true);
 Use **AsyncSingleton** for async initialization functions:
 
 ```ts
+import { AsyncSingleton } from "ts-singletonify";
+
 class ExampleService{
   initialize = false;
   async initialize(): Promise<void> {
@@ -78,13 +80,15 @@ class ExampleService{
   }
 }
 
-const singleton = AsyncSingleton(ExampleService)
-const instance1 = await singleton.getInstance();
-const instance2 = await singleton.getInstance();
+// AsyncSingleton is a Promise that will attempt to run initialize().
+const singleton = await AsyncSingleton(ExampleService)
+const instance1 = singleton.getInstance();
+const instance2 = singleton.getInstance();
 console.log(instance1 === instance2);
 ```
 
-**initialize function** can have any signature and accepts any parameters. You will need to pass these parameters into getInstance to get the instance.
+**initialize function** can have any signature and accepts any parameters. 
+You will need to pass these parameters into the Singleton or AsyncSingleton function.
 
 ```ts
 class ExampleService {
@@ -95,14 +99,61 @@ class ExampleService {
     this.initialized = true;
   }
 }
-const singleton = AsyncSingleton(ExampleService);
-//typescript will enforce the initialize signature with arg1: number and arg2: number
-const instance1 = await singleton.getInstance(2, 3);  
-const instance2 = await singleton.getInstance(); // X -> will complain
-expect(instance1).toBe(instance2);
+
+//typescript will enforce the initialize signature with arg1: number and arg2: number to be passed to AsyncSingleton
+const singleton = await AsyncSingleton(ExampleService, 2, 3);
+const instance1 = singleton.getInstance();  
+const instance2 = singleton.getInstance(); 
 ```
 
-***NOTE*** If you currently have a constructor that takes some arguments you will need to move this logic into the initialize function instead and pass arguments to getInstance. If your constructor doesn't take any params it is alright to have some logic going on.
+You can spread them as well ...[2,3] 
+
+```ts
+class ExampleService {
+  initialized = false;
+
+  async initialize(arg1: number, arg2: number): Promise<void> {
+    await new Promise((res) => setTimeout(res, 100));
+    this.initialized = true;
+  }
+}
+
+const singleton = await AsyncSingleton(ExampleService, ...[2, 3]);
+const instance1 = singleton.getInstance();  
+const instance2 = singleton.getInstance();
+console.log(instance1 === instance2) // true
+console.log(instance1.initialized) // true
+```
+
+or just pass an object for readability
+```ts
+class ExampleService {
+  initialized: boolean = false;
+  params: { arg1: string; arg2: number[] };
+
+  constructor() {
+    this.initialized = true;
+  }
+
+  initialize(params: { arg1: string; arg2: number[] }) {
+    this.params = {
+      arg1: params.arg1,
+      arg2: params.arg2,
+    };
+  }
+}
+const params = {
+  arg1: "test",
+  arg2: [123, 12],
+};
+
+// AsyncSingleton enforces params to be { arg1: string, arg2: number[] }
+const singleton = await AsyncSingleton(ExampleService, params);
+const instance1 = singleton.getInstance();
+const instance2 = singleton.getInstance();
+```
+
+***NOTE*** If you currently have a constructor that takes some arguments you will need to move this logic into the initialize function instead. If your constructor doesn't take any params it is alright to have some logic going on.
 
 ## ⚙️ Build
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-singletonify",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "A Typescript utility to enforce singleton instances",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-singletonify",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Typescript utility to enforce singleton instances",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,48 +1,48 @@
-import {
-  ExtractArgs,
-  SingletonClass,
-  AsyncSingletonClass,
-  instanceInitializeGuard,
-} from "./types";
+import { ExtractArgs, SingletonClass, instanceInitializeGuard } from "./types";
 
-function Singleton<T, TArgs extends any[] = ExtractArgs<T>>(
-  Base: new () => T
-): SingletonClass<T, TArgs> {
+function Singleton<T, TArgs extends ExtractArgs<T>>(
+  Base: new () => T,
+  ...args: TArgs
+): SingletonClass<T> {
   abstract class SingletonBase {
     private static instance: T;
 
     protected constructor() {}
 
-    public static getInstance(...args: TArgs): T {
+    public static getInstance(): T {
       if (!this.instance) {
         this.instance = new Base();
-        if (instanceInitializeGuard(this.instance)) {
-          this.instance.initialize?.(...args);
-        }
       }
       return this.instance;
     }
   }
+
+  const instance = SingletonBase.getInstance();
+  if (instanceInitializeGuard(instance)) {
+    instance.initialize?.(...args);
+  }
   return SingletonBase;
 }
 
-function AsyncSingleton<T, TArgs extends any[] = ExtractArgs<T>>(
-  Base: new () => T
-): AsyncSingletonClass<T, TArgs> {
+async function AsyncSingleton<T, TArgs extends ExtractArgs<T>>(
+  Base: new () => T,
+  ...args: TArgs
+): Promise<SingletonClass<T>> {
   abstract class SingletonBase {
     private static instance: T;
 
     protected constructor() {}
 
-    public static async getInstance(...args: TArgs): Promise<T> {
+    public static getInstance(): T {
       if (!this.instance) {
         this.instance = new Base();
-        if (instanceInitializeGuard(this.instance)) {
-          await this.instance.initialize(...args);
-        }
       }
       return this.instance;
     }
+  }
+  const instance = SingletonBase.getInstance();
+  if (instanceInitializeGuard(instance)) {
+    await instance.initialize(...args);
   }
   return SingletonBase;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,27 +4,17 @@ export type Promisify<T> = {
     : T[K];
 };
 
-export type SingletonClass<T, TArgs extends any[] = []> = {
-  getInstance: (...args: TArgs) => T;
+export type SingletonClass<T> = {
+  getInstance: () => T;
 };
-
-export type AsyncSingletonClass<T, TArgs extends any[] = []> = Promisify<
-  SingletonClass<T, TArgs>
->;
-
-export interface Initializable<TArgs extends any[] = []> {
-  initialize?: (...args: TArgs) => void | Promise<void>;
-}
 
 export type ExtractArgs<T> = T extends {
   initialize?: (...args: infer A) => any;
 }
-  ? A
-  : [];
-
-export interface Initializable<TArgs extends any[] = []> {
-  initialize?: (...args: TArgs) => void | Promise<void>;
-}
+  ? A extends []
+    ? never[]
+    : A
+  : never[];
 
 export function instanceInitializeGuard<T>(
   instance: T

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -56,22 +56,70 @@ describe("Singleton", () => {
         this.initialized = true;
       }
     }
-    const singleton = Singleton(ExampleService);
-    const instance1 = singleton.getInstance("test", 12);
-    const instance2 = singleton.getInstance("broom vroom", 89); // these doesn't matter since initialize will run only once on previous line
+    const singleton = Singleton(ExampleService, firstArg, secondArg);
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
     expect(instance1).toBe(instance2);
     expect(instance1.initialized).toBe(true);
+  });
+
+  it("should work with initialize params as object", () => {
+    const firstArg = "test";
+    const secondArg = 12;
+    class ExampleService {
+      initialized = false;
+      initialize(params: { firstArg: string; secondArg: number }): void {
+        expect(this.initialized).toBe(false);
+        expect(params.firstArg).toBe(firstArg);
+        expect(params.secondArg).toBe(secondArg);
+        this.initialized = true;
+      }
+    }
+    const singleton = Singleton(ExampleService, { firstArg, secondArg });
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
+    expect(instance1).toBe(instance2);
+    expect(instance1.initialized).toBe(true);
+  });
+
+  it("should work with initialize and constructor argumentless logic", () => {
+    class ExampleService {
+      initialized: boolean = false;
+      params: { arg1: string; arg2: number[] };
+
+      constructor() {
+        this.initialized = true;
+      }
+
+      initialize(params: { arg1: string; arg2: number[] }) {
+        this.params = {
+          arg1: params.arg1,
+          arg2: params.arg2,
+        };
+      }
+    }
+    const params = {
+      arg1: "test",
+      arg2: [123, 12],
+    };
+    const singleton = Singleton(ExampleService, params);
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
+    expect(instance1).toBe(instance2);
+    expect(instance1.initialized).toBe(true);
+    expect(instance1.params).toStrictEqual(params);
   });
 });
 
 describe("AsyncSingleton", () => {
   it("should work without initialize", async () => {
     class ExampleService {}
-    const singleton = AsyncSingleton(ExampleService);
-    const instance1 = await singleton.getInstance();
-    const instance2 = await singleton.getInstance();
+    const singleton = await AsyncSingleton(ExampleService);
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
     expect(instance1).toBe(instance2);
   });
+
   it("should work with initialize", async () => {
     class ExampleService {
       initialized = false;
@@ -83,9 +131,9 @@ describe("AsyncSingleton", () => {
       }
     }
 
-    const singleton = AsyncSingleton(ExampleService);
-    const instance1 = await singleton.getInstance();
-    const instance2 = await singleton.getInstance();
+    const singleton = await AsyncSingleton(ExampleService);
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
     expect(instance1).toBe(instance2);
     expect(instance1.initialized).toBe(true);
   });
@@ -96,18 +144,77 @@ describe("AsyncSingleton", () => {
     class ExampleService {
       initialized = false;
 
-      async initialize(arg1: number, arg2: number): Promise<void> {
+      async initialize(params: {
+        testValue1: number;
+        testValue2: number;
+      }): Promise<void> {
         expect(this.initialized).toBe(false);
-        expect(arg1).toBe(testValue1);
-        expect(arg2).toBe(testValue2);
+        expect(params.testValue1).toBe(testValue1);
+        expect(params.testValue2).toBe(testValue2);
         await new Promise((res) => setTimeout(res, 100));
         this.initialized = true;
       }
     }
-    const singleton = AsyncSingleton(ExampleService);
-    const instance1 = await singleton.getInstance(testValue1, testValue2);
-    const instance2 = await singleton.getInstance(2, 3);
+    const singleton = await AsyncSingleton(ExampleService, {
+      testValue1,
+      testValue2,
+    });
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
     expect(instance1).toBe(instance2);
     expect(instance1.initialized).toBe(true);
+  });
+
+  it("should work with initialize params as object", async () => {
+    const firstArg = "test";
+    const secondArg = 12;
+    class ExampleService {
+      initialized = false;
+      async initialize(params: {
+        firstArg: string;
+        secondArg: number;
+      }): Promise<void> {
+        expect(this.initialized).toBe(false);
+        expect(params.firstArg).toBe(firstArg);
+        expect(params.secondArg).toBe(secondArg);
+        this.initialized = true;
+      }
+    }
+    const singleton = await AsyncSingleton(ExampleService, {
+      firstArg,
+      secondArg,
+    });
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
+    expect(instance1).toBe(instance2);
+    expect(instance1.initialized).toBe(true);
+  });
+
+  it("should work with initialize and constructor argumentless logic", async () => {
+    class ExampleService {
+      initialized: boolean = false;
+      params: { arg1: string; arg2: number[] };
+
+      constructor() {
+        this.initialized = true;
+      }
+
+      initialize(params: { arg1: string; arg2: number[] }) {
+        this.params = {
+          arg1: params.arg1,
+          arg2: params.arg2,
+        };
+      }
+    }
+    const params = {
+      arg1: "test",
+      arg2: [123, 12],
+    };
+    const singleton = await AsyncSingleton(ExampleService, params);
+    const instance1 = singleton.getInstance();
+    const instance2 = singleton.getInstance();
+    expect(instance1).toBe(instance2);
+    expect(instance1.initialized).toBe(true);
+    expect(instance1.params).toStrictEqual(params);
   });
 });


### PR DESCRIPTION
Better usage for Singleton and AsyncSingleton functions. Instead of passing the initialize params into getInstance better to pass them into Singleton or AsyncSingleton once and not bother with them anymore.

Both functions will attempt to run an initialize function with the provided arguments if such exists in the corresponding class. 
AsyncSingleton is now an async function that will return a promise. 